### PR TITLE
create nightly image runner#37

### DIFF
--- a/dockerfile.nightly
+++ b/dockerfile.nightly
@@ -1,0 +1,45 @@
+#===============================
+# Compiling
+#===============================
+FROM node:14.16.1-slim AS Compiling
+
+RUN echo "⚠⚠⚠⚠⚠⚠  WARNING  ⚠⚠⚠⚠⚠⚠"
+RUN echo "This Docker Image Has GCP Credential Files!"
+RUN echo "Don't Publish in Public!"
+
+WORKDIR /compile
+
+COPY . ./
+
+# `@types/**` なども含めてインストール
+RUN yarn --frozen-lockfile
+
+# TSをJSにトランスパイル
+RUN yarn compile
+
+
+#===============================
+# Running Modules Install
+#===============================
+FROM node:14.16.1-slim AS node_modules
+
+WORKDIR /modules
+COPY package.json yarn.lock ./
+
+# `@types/**` などを省いてインストール
+RUN yarn --production --frozen-lockfile
+
+
+#===============================
+# Run
+#===============================
+FROM node:14.16.1-slim
+
+WORKDIR /usr/src/HikakinSymmetry/nodeBot
+
+COPY package.json yarn.lock ./
+COPY .envs ./.envs/
+COPY --from=Compiling /compile/dist ./dist/
+COPY --from=node_modules /modules/node_modules ./node_modules
+
+CMD ["yarn", "start:nightly"]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node dist/index.js",
 		"start:develop": "NODE_ENV=develop ts-node --files src/index.ts",
+		"start:nightly": "NODE_ENV=develop node dist/index.js",
     "compile": "tsc",
     "lint": "eslint src/ --ext ts",
     "lint:fix": "eslint src/ --ext ts --fix",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
 		"start:develop": "NODE_ENV=develop ts-node --files src/index.ts",
     "compile": "tsc",
     "lint": "eslint src/ --ext ts",
-    "lint:fix": "eslint src/ --ext ts --fix"
+    "lint:fix": "eslint src/ --ext ts --fix",
+		"build": "docker build . -t hikakinsymmetry/nodebot:latest",
+		"build:nightly": "docker build -f ./dockerfile.nightly -t hikakinsymmetry/nodebot:nightly ."
   },
   "devDependencies": {
     "typescript": "^4.3.2",


### PR DESCRIPTION
- `build` と `build:nightly` でイメージを作れるようにした
- nightly のコンテナ内部で動かすdockerfile を作成
- nightly 専用のエントリーポイントを追加

close #37
